### PR TITLE
Set the java /javascript diagram links to the local image

### DIFF
--- a/docs/mvp.adoc
+++ b/docs/mvp.adoc
@@ -34,13 +34,13 @@ image::detailed-workflow.png[detailed workflow]
 
 === Java (Backend)
 
-image::tssc-java-tools.png[link="https://www.lucidchart.com/documents/view/686183c6-821a-42a8-a71a-44dbc594de91/aG9PKqQUuCDz"]
+image::tssc-java-tools.png[link="{imagesdir}/tssc-java-tools.png"]
 
 https://www.lucidchart.com/documents/view/686183c6-821a-42a8-a71a-44dbc594de91/aG9PKqQUuCDz[LucidChart Java (Backend) TSSC]
 
 === JavaScript (Frontend)
 
-image::tssc-javascript-tools.png[link="https://www.lucidchart.com/documents/view/c9bb007f-3d24-4800-ab52-ad6c972752eb"]
+image::tssc-javascript-tools.png[link="{imagesdir}/tssc-javascript-tools.png"]
 
 https://www.lucidchart.com/documents/view/c9bb007f-3d24-4800-ab52-ad6c972752eb[LucidChart Javascript (Frontend) TSSC]
 


### PR DESCRIPTION
Tried the embedded lucid chart approach as well as custom html / css however this simple approach  yielded the best results. Embedded lucid chart places their entire javascript navigator in the page  which is slow to load and doesn't fit the image to the entire screen.